### PR TITLE
Add missing "version.h" file in installation.

### DIFF
--- a/cppunit/include/cppunit/Makefile.am
+++ b/cppunit/include/cppunit/Makefile.am
@@ -5,7 +5,8 @@ DISTCLEANFILES = config-auto.h
 libcppunitincludedir = $(includedir)/cppunit
 libcppunitinclude_HEADERS =  \
 	config-auto.h \
-  AdditionalMessage.h \
+	version.h \
+	AdditionalMessage.h \
 	Asserter.h \
 	BriefTestProgressListener.h \
 	CompilerOutputter.h \
@@ -16,17 +17,18 @@ libcppunitinclude_HEADERS =  \
 	Protector.h \
 	SourceLine.h \
 	SynchronizedObject.h \
-	Test.h \
 	TestAssert.h \
-	TestCase.h \
 	TestCaller.h \
+	TestCase.h \
 	TestComposite.h \
 	TestFailure.h \
 	TestFixture.h \
+	Test.h \
 	TestLeaf.h \
+	TestListener.h \
 	TestPath.h \
-	TestResult.h \
 	TestResultCollector.h \
+	TestResult.h \
 	TestRunner.h \
 	TestSuccessListener.h \
 	TestSuite.h \
@@ -34,7 +36,6 @@ libcppunitinclude_HEADERS =  \
 	TextTestProgressListener.h \
 	TextTestResult.h \
 	TextTestRunner.h \
-	TestListener.h \
 	XmlOutputter.h \
 	XmlOutputterHook.h
 


### PR DESCRIPTION
The `make install` command succeeds but the new `version.h` file is not copied, resulting in a compilation error on client programs. An example of the error follows below:

```
In file included from /opt/cppunit/include/cppunit/CompilerOutputter.h:4:0,
                 from test.cpp:5:
/opt/cppunit/include/cppunit/Portability.h:8:21: fatal error: version.h: No such file or directory
compilation terminated.
```

I took the liberty to sort correctly the header files list too.
